### PR TITLE
Call setRegister in setBit.

### DIFF
--- a/Adafruit_MCP23017.cpp
+++ b/Adafruit_MCP23017.cpp
@@ -702,6 +702,8 @@ void Adafruit_MCP23017::setBit(uint8_t reg, uint8_t bitpos, uint8_t bitval) {
 	} else {
 	    current = current | (1 << bitpos);
 	}
+	
+	setRegister(reg, current);
 }
 
 /**


### PR DESCRIPTION
`setRegister` was never called in `setBit`, therefor the bit's weren't actually set to the MCP.